### PR TITLE
Improved product search

### DIFF
--- a/apps/backend/src/main/java/no/ntnu/webshop/config/SqlFunctionsMetadataBuilderContributor.java
+++ b/apps/backend/src/main/java/no/ntnu/webshop/config/SqlFunctionsMetadataBuilderContributor.java
@@ -7,6 +7,16 @@ import org.hibernate.type.StandardBasicTypes;
 
 public class SqlFunctionsMetadataBuilderContributor implements MetadataBuilderContributor {
 
+  /**
+   * Contributes to the {@link MetadataBuilder} by adding the SQL function "SIMILARITY" which is
+   * provided by the "pg_trgm" extension in Postgres. This class file is referenced from the
+   * application properties, resulting in it being applied.
+   * 
+   * This essentially allows us to use the SIMILARITY() function in JPQL queries.
+   * 
+   * @see no.ntnu.webshop.repository.ProductJpaRepository#findProducts An example of this function
+   *      being used
+   */
   @Override
   public void contribute(
       MetadataBuilder metadataBuilder

--- a/apps/backend/src/main/java/no/ntnu/webshop/config/SqlFunctionsMetadataBuilderContributor.java
+++ b/apps/backend/src/main/java/no/ntnu/webshop/config/SqlFunctionsMetadataBuilderContributor.java
@@ -1,0 +1,23 @@
+package no.ntnu.webshop.config;
+
+import org.hibernate.boot.MetadataBuilder;
+import org.hibernate.boot.spi.MetadataBuilderContributor;
+import org.hibernate.dialect.function.StandardSQLFunction;
+import org.hibernate.type.StandardBasicTypes;
+
+public class SqlFunctionsMetadataBuilderContributor implements MetadataBuilderContributor {
+
+  @Override
+  public void contribute(
+      MetadataBuilder metadataBuilder
+  ) {
+    metadataBuilder.applySqlFunction(
+      "SIMILARITY",
+      new StandardSQLFunction(
+        "SIMILARITY",
+        StandardBasicTypes.TEXT
+      )
+    );
+  }
+
+}

--- a/apps/backend/src/main/java/no/ntnu/webshop/controller/OrderController.java
+++ b/apps/backend/src/main/java/no/ntnu/webshop/controller/OrderController.java
@@ -5,6 +5,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.format.annotation.DateTimeFormat.ISO;
@@ -62,8 +63,13 @@ public class OrderController {
 
   @Operation(summary = "Lists all orders")
   @GetMapping
-  public ResponseEntity<List<OrderDetails>> findOrders() {
-    return ResponseEntity.ok(this.orderJdbcRepository.findOrders(Optional.empty(), Optional.empty(), Optional.empty()));
+  public ResponseEntity<List<OrderDetails>> findOrders(
+      @Parameter(description = "The id of the customer to find orders for")
+      @RequestParam(value = "customerId", required = false) Optional<UUID> customerId,
+      @Parameter(description = "The name of the product to find orders for, can be a case insensitive partial match")
+      @RequestParam(value = "productName", required = false) Optional<String> productName
+  ) {
+    return ResponseEntity.ok(this.orderJdbcRepository.findOrders(customerId, productName, Optional.empty()));
   }
 
   @Operation(summary = "Updates an orders statuses")

--- a/apps/backend/src/main/java/no/ntnu/webshop/controller/UserContextOrderController.java
+++ b/apps/backend/src/main/java/no/ntnu/webshop/controller/UserContextOrderController.java
@@ -60,6 +60,7 @@ public class UserContextOrderController {
   @GetMapping
   public ResponseEntity<List<OrderDetails>> findOrders(
       @AuthenticationPrincipal UserAccountDetailsAdapter adapter,
+      @Parameter(description = "The name of the product to find orders for, can be a case insensitive partial match")
       @RequestParam("productName") Optional<String> productName
   ) {
     var userId = adapter.getUserAccount().getId();

--- a/apps/backend/src/main/java/no/ntnu/webshop/repository/ProductJpaRepository.java
+++ b/apps/backend/src/main/java/no/ntnu/webshop/repository/ProductJpaRepository.java
@@ -44,7 +44,7 @@ public interface ProductJpaRepository extends JpaRepository<Product, Long> {
       AND prev_pp.to = pp.from
     WHERE
       ((COALESCE(:id) IS NULL AND :allowEmptyIdList = TRUE) OR p.id IN (:id)) AND
-      (:name IS NULL OR p.name ILIKE %:name%) AND
+      (:name IS NULL OR (SIMILARITY(p.name, :name) > 0.3 OR p.name ILIKE %:name%)) AND
       (COALESCE(:category) IS NULL OR p.id IN (
         SELECT DISTINCT p.id
         FROM Category c

--- a/apps/backend/src/main/resources/application.properties
+++ b/apps/backend/src/main/resources/application.properties
@@ -8,6 +8,8 @@ spring.datasource.username=${POSTGRES_USER}
 spring.datasource.password=${POSTGRES_PASSWORD}
 spring.datasource.driverClassName=org.postgresql.Driver
 
+spring.jpa.properties.hibernate.metadata_builder_contributor=no.ntnu.webshop.config.SqlFunctionsMetadataBuilderContributor
+
 no.ntnu.webshop.jwt.token-issuer=${TOKEN_ISSUER}
 no.ntnu.webshop.jwt.access-token-secret=${ACCESS_TOKEN_SECRET}
 no.ntnu.webshop.jwt.refresh-token-secret=${REFRESH_TOKEN_SECRET}

--- a/packages/migrations/src/main/resources/db/changelog/001-search/000-extension.sql
+++ b/packages/migrations/src/main/resources/db/changelog/001-search/000-extension.sql
@@ -1,0 +1,1 @@
+CREATE EXTENSION "pg_trgm";

--- a/packages/migrations/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/packages/migrations/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -25,5 +25,4 @@ databaseChangeLog:
       changes:
         - sqlFile:
             path: changelog/001-search/000-extension.sql
-            dbms: postgesql
             relativeToChangelogFile: true

--- a/packages/migrations/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/packages/migrations/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -19,3 +19,11 @@ databaseChangeLog:
         - sqlFile:
             path: changelog/000-initial/004-orders.sql
             relativeToChangelogFile: true
+  - changeSet:
+      id: 001-search
+      author: thedatasnok, GBfur, dawsta27
+      changes:
+        - sqlFile:
+            path: changelog/001-search/000-extension.sql
+            dbms: postgesql
+            relativeToChangelogFile: true


### PR DESCRIPTION
This is a slight improvement to the product search employing the "pg_trgm" extension in Postgres to allow for showing products with similar names to the search input. 

This will cover typos to some extent, but it will not handle a keyword-based full text search.

Also added in options to find orders for customers, and a minor improvement to openapi documentation.